### PR TITLE
Internal review: dev-apis: platform: Add target for nRF5340 and nRF9160

### DIFF
--- a/api-tests/dev_apis/crypto/test_c019/test_c019.c
+++ b/api-tests/dev_apis/crypto/test_c019/test_c019.c
@@ -104,7 +104,7 @@ int32_t psa_key_derivation_key_agreement_test(caller_security_t caller __UNUSED)
 int32_t psa_key_derivation_key_agreement_negative_test(caller_security_t caller __UNUSED)
 {
     int32_t                         status;
-    psa_key_derivation_operation_t  operation;
+    psa_key_derivation_operation_t  operation = PSA_KEY_DERIVATION_OPERATION_INIT;
     psa_key_handle_t                key_handle = 8;
 
     if (valid_test_input_index < 0)

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_driver_intf.c
@@ -128,7 +128,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_attestation_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_attestation_config.h
@@ -1,0 +1,107 @@
+/** @file
+ * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_ATTESTATION_CONFIG_H_
+#define _PAL_ATTESTATION_CONFIG_H_
+
+#define COSE_ALGORITHM_ES256             -7
+#define COSE_ALG_SHA256_PROPRIETARY      -72000
+
+#define USEFUL_BUF_MAKE_STACK_UB UsefulBuf_MAKE_STACK_UB
+
+#define COSE_SIG_CONTEXT_STRING_SIGNATURE1 "Signature1"
+
+/* Private value. Intentionally not documented for Doxygen.
+ * This is the size allocated for the encoded protected headers.  It
+ * needs to be big enough for make_protected_header() to succeed. It
+ * currently sized for one header with an algorithm ID up to 32 bits
+ * long -- one byte for the wrapping map, one byte for the label, 5
+ * bytes for the ID. If this is made accidentially too small, QCBOR will
+ * only return an error, and not overrun any buffers.
+ *
+ * 9 extra bytes are added, rounding it up to 16 total, in case some
+ * other protected header is to be added.
+ */
+#define T_COSE_SIGN1_MAX_PROT_HEADER (1+1+5+9)
+
+/**
+ * This is the size of the first part of the CBOR encoded TBS
+ * bytes. It is around 20 bytes. See create_tbs_hash().
+ */
+#define T_COSE_SIZE_OF_TBS \
+    1 + /* For opening the array */ \
+    sizeof(COSE_SIG_CONTEXT_STRING_SIGNATURE1) + /* "Signature1" */ \
+    2 + /* Overhead for encoding string */ \
+    T_COSE_SIGN1_MAX_PROT_HEADER + /* entire protected headers */ \
+    3 * (/* 3 NULL bstrs for fields not used */ \
+        1 /* size of a NULL bstr */  \
+    )
+#define NULL_USEFUL_BUF_C  NULLUsefulBufC
+
+#define ATTEST_PUBLIC_KEY_SLOT                  4
+#define ECC_CURVE_SECP256R1_PULBIC_KEY_LENGTH   (1 + 2 * PSA_BITS_TO_BYTES(256))
+
+typedef struct {
+    uint8_t  *pubx_key;
+    size_t    pubx_key_size;
+    uint8_t  *puby_key;
+    size_t    puby_key_size;
+} ecc_key_t;
+
+struct ecc_public_key_t {
+    const uint8_t a;
+    uint8_t public_key[]; /* X-coordinate || Y-coordinate */
+};
+
+static const struct ecc_public_key_t attest_public_key = {
+     /* Constant byte */
+     0x04,
+     /* X-coordinate */
+     {0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+      0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+      0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+      0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F,
+     /* Y-coordinate */
+      0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+      0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+      0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+      0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
+};
+
+static const uint8_t initial_attestation_public_x_key[] = {
+    0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+    0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+    0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+    0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F
+};
+
+static const uint8_t initial_attestation_public_y_key[] = {
+    0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+    0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+    0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+    0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64
+};
+
+/* Initialize the structure with given public key */
+static const ecc_key_t attest_key = {
+        (uint8_t *)initial_attestation_public_x_key,
+        sizeof(initial_attestation_public_x_key),
+        (uint8_t *)initial_attestation_public_y_key,
+        sizeof(initial_attestation_public_y_key)
+};
+
+#endif /* _PAL_ATTESTATION_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_config.h
@@ -1,0 +1,95 @@
+/** @file
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CONFIG_H_
+#define _PAL_CONFIG_H_
+
+#include "pal_crypto_config.h"
+#include "pal_attestation_config.h"
+#include "pal_storage_config.h"
+
+/* Define PSA test suite dependent macros for non-cmake build */
+#if !defined(PSA_CMAKE_BUILD)
+
+/* Print verbosity = TEST */
+#define VERBOSE 3
+
+/* NSPE or SPE VAL build? */
+#define VAL_NSPE_BUILD
+
+/* NSPE or SPE TEST build? */
+#define NONSECURE_TEST_BUILD
+
+/* If not defined, skip watchdog programming */
+#define WATCHDOG_AVAILABLE
+
+/* Are Dynamic memory APIs available to secure partition? */
+#define SP_HEAP_MEM_SUPP
+
+/* PSA Isolation level supported by platform */
+#define PLATFORM_PSA_ISOLATION_LEVEL 3
+#endif /* PSA_CMAKE_BUILD */
+
+/* Version of crypto spec used in attestation */
+#define CRYPTO_VERSION_BETA3
+
+/* Use hardcoded public key */
+//#define PLATFORM_OVERRIDE_ATTEST_PK
+
+/*
+ * Include of PSA defined Header files
+ */
+#ifdef IPC
+/* psa/client.h: Contains the PSA Client API elements */
+#include "psa/client.h"
+
+/*
+ * psa_manifest/sid.h:  Macro definitions derived from manifest files that map from RoT Service
+ * names to Service IDs (SIDs). Partition manifest parse build tool must provide the implementation
+ * of this file.
+*/
+#include "psa_manifest/sid.h"
+
+/*
+ * psa_manifest/pid.h: Secure Partition IDs
+ * Macro definitions that map from Secure Partition names to Secure Partition IDs.
+ * Partition manifest parse build tool must provide the implementation of this file.
+*/
+#include "psa_manifest/pid.h"
+#endif
+
+#ifdef CRYPTO
+/* psa/crypto.h: Contains the PSA Crypto API elements */
+#include "psa/crypto.h"
+#endif
+
+#if defined(INTERNAL_TRUSTED_STORAGE) || defined(STORAGE)
+/* psa/internal_trusted_storage.h: Contains the PSA ITS API elements */
+#include "psa/internal_trusted_storage.h"
+#endif
+
+#if defined(PROTECTED_STORAGE) || defined(STORAGE)
+/* psa/protected_storage.h: Contains the PSA PS API elements */
+#include "psa/protected_storage.h"
+#endif
+
+#ifdef INITIAL_ATTESTATION
+/* psa/initial_attestation.h: Contains the PSA Initial Attestation API elements */
+#include "psa/initial_attestation.h"
+#endif
+
+#endif /* _PAL_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_crypto_config.h
@@ -1,0 +1,329 @@
+/** @file
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+/*
+ * \file pal_crypto_config.h
+ *
+ * \brief Configuration options for crypto tests (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively for crypto test suite
+ */
+
+#ifndef _PAL_CRYPTO_CONFIG_H_
+#define _PAL_CRYPTO_CONFIG_H_
+/**
+ * \def ARCH_TEST_RSA
+ *
+ * Enable the RSA public-key cryptosystem.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_RSA
+#define ARCH_TEST_RSA_1024
+#define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_3072
+
+/**
+ * \def  ARCH_TEST_ECC
+ * \def  ARCH_TEST_ECC_CURVE_SECPXXXR1
+ *
+ * Enable the elliptic curve
+ * Enable specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Requires: ARCH_TEST_ECC
+ * Comment macros to disable the curve
+ */
+#define ARCH_TEST_ECC
+#define ARCH_TEST_ECC_CURVE_SECP192R1
+#define ARCH_TEST_ECC_CURVE_SECP224R1
+#define ARCH_TEST_ECC_CURVE_SECP256R1
+#define ARCH_TEST_ECC_CURVE_SECP384R1
+
+/**
+ * \def ARCH_TEST_AES
+ *
+ * Enable the AES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_AES
+#define ARCH_TEST_AES_128
+#define ARCH_TEST_AES_192
+#define ARCH_TEST_AES_256
+#define ARCH_TEST_AES_512
+
+/**
+ * \def  ARCH_TEST_DES
+ *
+ * Enable the DES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+//#define ARCH_TEST_DES
+//#define ARCH_TEST_DES_1KEY
+//#define ARCH_TEST_DES_2KEY
+//#define ARCH_TEST_DES_3KEY
+
+/**
+ * \def  ARCH_TEST_RAW
+ *
+ * A "key" of this type cannot be used for any cryptographic operation.
+ * Applications may use this type to store arbitrary data in the keystore.
+ */
+#define ARCH_TEST_RAW
+
+/**
+ * \def ARCH_TEST_CIPER
+ *
+ * Enable the generic cipher layer.
+ */
+
+#define ARCH_TEST_CIPER
+
+/**
+ * \def ARCH_TEST_ARC4
+ *
+ * Enable the ARC4 key type.
+ */
+//#define ARCH_TEST_ARC4
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CTR
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CFB
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CBC
+
+/**
+ * \def ARCH_TEST_CTR_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CTR
+ */
+#define ARCH_TEST_CTR_AES
+
+/**
+ * \def ARCH_TEST_CBC_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_AES
+#define ARCH_TEST_CBC_AES_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CBC_NO_PADDING
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CFB_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CFB
+ */
+#define ARCH_TEST_CFB_AES
+
+/**
+ * \def ARCH_TEST_PKCS1V15_*
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ * Enable support for PKCS#1 v1.5 operations.
+ * Enable support for RSA-OAEP
+ *
+ * Requires: ARCH_TEST_RSA, ARCH_TEST_PKCS1V15
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_PKCS1V15
+#define ARCH_TEST_RSA_PKCS1V15_SIGN
+#define ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
+#define ARCH_TEST_RSA_PKCS1V15_CRYPT
+#define ARCH_TEST_RSA_OAEP
+
+/**
+ * \def ARCH_TEST_CBC_PKCS7
+ *
+ * Requires: ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_PKCS7
+
+/**
+ * \def ARCH_TEST_ASYMMETRIC_ENCRYPTION
+ *
+ * Enable support for Asymmetric encryption algorithms
+ */
+#define ARCH_TEST_ASYMMETRIC_ENCRYPTION
+
+/**
+ * \def ARCH_TEST_HASH
+ *
+ * Enable the hash algorithm.
+ */
+#define ARCH_TEST_HASH
+
+/**
+ * \def  ARCH_TEST_HMAC
+ *
+ * The key policy determines which underlying hash algorithm the key can be
+ * used for.
+ *
+ * Requires: ARCH_TEST_HASH
+ */
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_MDX
+ * \def ARCH_TEST_SHAXXX
+ *
+ * Enable the MDX algorithm.
+ * Enable the SHAXXX algorithm.
+ *
+ * Requires: ARCH_TEST_HASH
+ *
+ * Comment macros to disable the types
+ */
+//#define ARCH_TEST_MD2
+//#define ARCH_TEST_MD4
+//#define ARCH_TEST_MD5
+//#define ARCH_TEST_RIPEMD160
+//#define ARCH_TEST_SHA1
+#define ARCH_TEST_SHA224
+#define ARCH_TEST_SHA256
+#define ARCH_TEST_SHA384
+#define ARCH_TEST_SHA512
+//#define ARCH_TEST_SHA512_224
+//#define ARCH_TEST_SHA512_256
+//#define ARCH_TEST_SHA3_224
+//#define ARCH_TEST_SHA3_256
+//#define ARCH_TEST_SHA3_384
+//#define ARCH_TEST_SHA3_512
+
+/**
+ * \def ARCH_TEST_HKDF
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_HKDF
+
+/**
+ * \def ARCH_TEST_xMAC
+ *
+ * Enable the xMAC (Cipher/Hash/G-based Message Authentication Code) mode for block
+ * ciphers.
+ * Requires: ARCH_TEST_AES or ARCH_TEST_DES
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CMAC
+//#define ARCH_TEST_GMAC
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_CCM
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Requires: ARCH_TEST_AES
+ */
+#define ARCH_TEST_CCM
+
+/**
+ * \def ARCH_TEST_GCM
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Requires: ARCH_TEST_AES
+ *
+ */
+#define ARCH_TEST_GCM
+
+/**
+ * \def ARCH_TEST_TRUNCATED_MAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+#define ARCH_TEST_TRUNCATED_MAC
+
+
+/**
+ * \def ARCH_TEST_ECDH
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Requires: ARCH_TEST_ECC
+ */
+#define ARCH_TEST_ECDH
+
+/**
+ * \def ARCH_TEST_ECDSA
+ *
+ * Enable the elliptic curve DSA library.
+ * Requires: ARCH_TEST_ECC
+ */
+#define ARCH_TEST_ECDSA
+
+/**
+ * \def ARCH_TEST_DETERMINISTIC_ECDSA
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+*/
+#define ARCH_TEST_DETERMINISTIC_ECDSA
+
+/**
+ * \def ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+ *
+ * Enable ECC support for asymmetric API.
+*/
+//#define ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+#include "pal_crypto_config_check.h"
+
+#endif /* _PAL_CRYPTO_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_driver_intf.c
@@ -1,0 +1,159 @@
+/** @file
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_nvmem.h"
+
+
+typedef void (*pal_uart_logger_t)(const char *fmt, int32_t data);
+static pal_uart_logger_t logger;
+
+/* Log the format string to UART. */
+pal_uart_logger_t pal_uart_get_logger(void);
+
+/* Initialize the timer with the given number of ticks. */
+void pal_timer_init_ns(uint32_t ticks);
+
+/* Start the timer. */
+void pal_timer_start_ns(void);
+
+/* Stop and resest the timer. */
+void pal_timer_stop_ns(void);
+
+/* Get the address of a free, word-aligned, 1K memory area. */
+uint32_t pal_nvmem_get_addr(void);
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(uint32_t uart_base_addr)
+{
+    (void)uart_base_addr;
+    logger = pal_uart_get_logger();
+    return logger ? PAL_STATUS_SUCCESS : PAL_STATUS_ERROR;
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+
+int pal_print_ns(const char *str, int32_t data)
+{
+    logger(str, data);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    (void)base_addr;
+    pal_timer_init_ns(time_us * timer_tick_us);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable_ns(addr_t base_addr)
+{
+    (void)base_addr;
+    pal_timer_start_ns();
+    return PAL_STATUS_SUCCESS;
+
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr  : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable_ns(addr_t base_addr)
+{
+    (void)base_addr;
+    pal_timer_stop_ns();
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    base = pal_nvmem_get_addr();
+    return nvmem_read(base, offset, buffer, size) ? PAL_STATUS_SUCCESS
+                                                  : PAL_STATUS_ERROR;
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    base = pal_nvmem_get_addr();
+    return nvmem_write(base, offset, buffer, size) ? PAL_STATUS_SUCCESS
+                                                   : PAL_STATUS_ERROR;
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while(1)
+    {
+        __asm volatile("WFI");
+    }
+}
+
+/**
+ *   @brief    - Resets the system.
+ *   @param    - void
+ *   @return   - SUCCESS/FAILURE
+**/
+int pal_system_reset(void)
+{
+    /* Reset functionality is not implemented. */
+    return PAL_STATUS_UNSUPPORTED_FUNC;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_storage_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/nspe/pal_storage_config.h
@@ -1,0 +1,24 @@
+/** @file
+ * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_STORAGE_CONFIG_H_
+#define _PAL_STORAGE_CONFIG_H_
+
+/* Platform specific max UID's size */
+#define ARCH_TEST_STORAGE_UID_MAX_SIZE 512
+
+#endif /* _PAL_STORAGE_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cfg
@@ -1,0 +1,34 @@
+///** @file
+// * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+// * SPDX-License-Identifier : Apache-2.0
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *  http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+//**/
+
+// UART device info
+uart.num=1;
+uart.0.base = 0; // Unused value
+
+// Watchdog device info
+watchdog.num = 1;
+watchdog.0.base = 0; // Unused value
+watchdog.0.num_of_tick_per_micro_sec = 1;
+watchdog.0.timeout_in_micro_sec_low = 0xF4240;      //1.0  sec :  1 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_medium = 0x1E8480;  //2.0  sec :  2 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_high = 0x4C4B40;    //5.0  sec :  5 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 1000
+
+// Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
+nvmem.num =1;
+nvmem.0.start = 0; // Unused value;
+nvmem.0.end = 0x3ff;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cmake
@@ -1,0 +1,89 @@
+#/** @file
+# * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE )
+
+# PAL ASM source files part of NSPE library
+list(APPEND PAL_SRC_ASM_NSPE )
+
+# PAL C source files part of SPE library - driver partition
+list(APPEND PAL_SRC_C_DRIVER_SP )
+
+# PAL ASM source files part of SPE library - driver partition
+list(APPEND PAL_SRC_ASM_DRIVER_SP )
+
+# Listing all the sources required for given target
+if(${SUITE} STREQUAL "IPC")
+	message(FATAL_ERROR "For IPC - use -DTARGET=tgt_ff_tfm_nrf* instead")
+else()
+	list(APPEND PAL_SRC_C_NSPE
+		# driver files will be compiled as part of NSPE
+		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_intf.c
+		${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+	)
+endif()
+
+if(${SUITE} STREQUAL "CRYPTO")
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto/pal_crypto_intf.c
+	)
+endif()
+if((${SUITE} STREQUAL "PROTECTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage/pal_protected_storage_intf.c
+	)
+endif()
+if((${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+	)
+endif()
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_intf.c
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
+                ${CMAKE_CURRENT_BINARY_DIR}/${PSA_TARGET_QCBOR}/src/UsefulBuf.c
+                ${CMAKE_CURRENT_BINARY_DIR}/${PSA_TARGET_QCBOR}/src/ieee754.c
+                ${CMAKE_CURRENT_BINARY_DIR}/${PSA_TARGET_QCBOR}/src/qcbor_decode.c
+                ${CMAKE_CURRENT_BINARY_DIR}/${PSA_TARGET_QCBOR}/src/qcbor_encode.c
+	)
+endif()
+
+# Create NSPE library
+add_library(${PSA_TARGET_PAL_NSPE_LIB} STATIC ${PAL_SRC_C_NSPE} ${PAL_SRC_ASM_NSPE})
+
+# PSA Include directories
+foreach(psa_inc_path ${PSA_INCLUDE_PATHS})
+	target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE ${psa_inc_path})
+endforeach()
+
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+	${PSA_ROOT_DIR}/platform/targets/common/nspe
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
+	${PSA_ROOT_DIR}/platform/drivers/nvmem
+	${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
+)
+
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+	${PSA_QCBOR_INCLUDE_PATH}
+)
+endif()

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
@@ -137,7 +137,7 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/api-tests/platform/targets/tgt_ff_tfm_musca_b1/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_musca_b1/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/tbsa-v8m/tbsa_app/tbsa_main.c
+++ b/tbsa-v8m/tbsa_app/tbsa_main.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/tbsa_app/tbsa_main.c
+++ b/tbsa-v8m/tbsa_app/tbsa_main.c
@@ -71,6 +71,6 @@ void tbsa_main (void)
 
 exit:
     while(1) {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/tbsa-v8m/test_pool/base/test_b001/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b001/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/base/test_b001/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b001/secure.c
@@ -55,16 +55,16 @@ void hard_fault_esr(unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 tbsa_status_t setup_ns_env(void)

--- a/tbsa-v8m/test_pool/base/test_b005/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b005/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/base/test_b005/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b005/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/base/test_b006/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b006/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/base/test_b006/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b006/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
@@ -99,8 +99,8 @@ void test_payload(tbsa_val_api_t *val)
 
         /* Shouldn't come here */
         val->print(PRINT_ERROR, "\n\r\tFault didn't occur when HUK accessed from Non-secure world!", 0);
-        asm volatile ("DSB");
-        asm volatile ("ISB");
+        __asm volatile ("DSB");
+        __asm volatile ("ISB");
         val->system_reset(WARM_RESET);
     }
 }

--- a/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/crypto/test_c003/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/secure.c
@@ -48,8 +48,8 @@ void hard_fault_esr (unsigned long *sf_args)
     g_val->print(PRINT_DEBUG, "\n\r\tHardFault triggered when HUK was accessed from"
                  "non-Trusted world", 0);
 
-    asm volatile("DSB");
-    asm volatile("ISB");
+    __asm volatile("DSB");
+    __asm volatile("ISB");
 
     g_val->system_reset(WARM_RESET);
 
@@ -59,16 +59,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void test_payload(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c003/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
@@ -150,8 +150,8 @@ void test_payload(tbsa_val_api_t *val)
 
     /* Control shouldn't come here */
     val->print(PRINT_ERROR, "\n\r\tFault didn't occur when Trusted HW Key accessed from Non-secure world!", 0);
-    asm volatile ("DSB");
-    asm volatile ("ISB");
+    __asm volatile ("DSB");
+    __asm volatile ("ISB");
     val->system_reset(WARM_RESET);
 }
 

--- a/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/crypto/test_c006/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/secure.c
@@ -45,16 +45,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c006/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/crypto/test_c011/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c011/secure.c
@@ -130,9 +130,9 @@ void test_payload(tbsa_val_api_t *val)
         }
 
         /* Change the mode to unprivilege access */
-        asm volatile ("MRS %0, control" : "=r" (control));
+        __asm volatile ("MRS %0, control" : "=r" (control));
         control |= 0x1;
-        asm volatile ("MSR control, %0" : : "r" (control) : "memory");
+        __asm volatile ("MSR control, %0" : : "r" (control) : "memory");
 
         /* Performing unprivilege access to Confidential fuse */
         status = val->fuse_ops(FUSE_READ, fuse_desc->addr, data1, MIN(FUSE_SIZE, fuse_desc->size));

--- a/tbsa-v8m/test_pool/crypto/test_c011/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c011/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/debug/test_d003/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d003/secure.c
@@ -39,7 +39,7 @@ void delay (uint32_t delay_cnt)
 {
     while(delay_cnt--)
     {
-        asm volatile("NOP");
+        __asm volatile("NOP");
     }
 }
 
@@ -196,8 +196,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_9, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /* Indicate the debugger about the transition to CLOSED state */
                     if (test_dbg_seq_write((uint32_t)(memory_desc->start), SEQ_CLOSED_STATE_READ)) {
@@ -226,8 +226,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_B, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /*Initialize the memory with known data*/
                     val->mem_write((uint32_t *)memory_desc->start, WORD, ~TEST_DATA);
@@ -245,8 +245,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_C, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /* Indicate the debugger about the transition to CLOSED state */
                     if (test_dbg_seq_write((uint32_t)(memory_desc->start), SEQ_CLOSED_STATE_WRITE)) {
@@ -272,8 +272,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_E, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
                 }
                 instance++;
             } while (instance < GET_NUM_INSTANCE(memory_desc));

--- a/tbsa-v8m/test_pool/debug/test_d003/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d003/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/debug/test_d008/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d008/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/debug/test_d008/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d008/secure.c
@@ -129,9 +129,9 @@ void test_payload(tbsa_val_api_t *val)
                  }
 
                  /* Change the mode to unprivilege access */
-                 asm volatile ("MRS %0, control" : "=r" (control));
+                 __asm volatile ("MRS %0, control" : "=r" (control));
                  control |= 0x1;
-                 asm volatile ("MSR control, %0" : : "r" (control) : "memory");
+                 __asm volatile ("MSR control, %0" : : "r" (control) : "memory");
 
                  /* Performing unprivilege access to DPM */
                  certificate_valid[dpm_instance] = val->crypto_validate_certificate(dpm_desc->certificate_addr, dpm_desc->public_key_addr, dpm_desc->certificate_size,dpm_desc->public_key_size);

--- a/tbsa-v8m/test_pool/mem/test_m001/secure.c
+++ b/tbsa-v8m/test_pool/mem/test_m001/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/mem/test_m001/secure.c
+++ b/tbsa-v8m/test_pool/mem/test_m001/secure.c
@@ -46,16 +46,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 tbsa_status_t setup_ns_env(void)

--- a/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
+++ b/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
@@ -42,16 +42,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
+++ b/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/timer/test_t001/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t001/secure.c
@@ -58,16 +58,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t001/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t001/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/timer/test_t002/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t002/secure.c
@@ -52,16 +52,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t002/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t002/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/timer/test_t003/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t003/secure.c
@@ -43,16 +43,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t003/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t003/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
+++ b/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
+++ b/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/val/src/val_debug.c
+++ b/tbsa-v8m/val/src/val_debug.c
@@ -118,16 +118,16 @@ tbsa_status_t val_debug_set_status(dbg_access_t dbg_access, dbg_seq_status_t dbg
                 return TBSA_STATUS_TIMEOUT;
             }
             *(uint32_t *)dpm_desc->flag_addr = dbg_status;
-            asm volatile("DSB");
-            asm volatile("ISB");
+            __asm volatile("DSB");
+            __asm volatile("ISB");
             break;
         case DBG_WRITE:
             *(uint32_t *)dpm_desc->flag_addr = dbg_status | DBG_FLAG_TXFULL;
             break;
         case DBG_READ:
             *(uint32_t *)dpm_desc->flag_addr &= ~DBG_FLAG_RXFULL;
-            asm volatile("DSB");
-            asm volatile("ISB");
+            __asm volatile("DSB");
+            __asm volatile("ISB");
             break;
         default:
             return TBSA_STATUS_INCORRECT_VALUE;

--- a/tbsa-v8m/val/src/val_debug.c
+++ b/tbsa-v8m/val/src/val_debug.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tbsa-v8m/val/src/val_ns_callable.c
+++ b/tbsa-v8m/val/src/val_ns_callable.c
@@ -22,7 +22,7 @@
 #define TRANSITION_NS_TO_S(fn_ret, fn_name, ...) \
     __attribute__((section(".tbsa_nsc_entry_points"), naked)) \
     fn_ret fn_name ## _nsc(__VA_ARGS__) { \
-        asm volatile( \
+        __asm volatile( \
             "sg                   \n" \
             "push {r7}            \n" \
             "push {lr}            \n" \

--- a/tbsa-v8m/val/src/val_ns_callable.c
+++ b/tbsa-v8m/val/src/val_ns_callable.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Add tgt_dev_apis_tfm_nrf which can be used for both nRF5340 and nRF9160.

Most of the porting is offloaded to the project that includes this.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>